### PR TITLE
Add not-invalid-this rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = {
     'no-mixed-operators': 'off',
     'function-paren-newline': 'off',
     'object-curly-newline': 'off',
+    'no-invalid-this': 'error',
     'comma-dangle': [
       'error',
       {


### PR DESCRIPTION
not-invalid-this rule has been an issue once in a project, but this is something that a linter should be able to catch. For more information see https://eslint.org/docs/latest/rules/no-invalid-this

![image](https://github.com/user-attachments/assets/6ee56d05-82dc-4c8a-a732-e5756407a028)
