### PR TITLE
Enforce no-nested-ternary rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = {
     '@quave/meteor-quave/template-names': ['off'],
     'import/no-default-export': 'error',
     'import/first': 'off',
-    'no-nested-ternary': 'off',
+    'no-nested-ternary': 'error',
     eqeqeq: 'off',
     'global-require': 0,
     'react/function-component-definition': 0,


### PR DESCRIPTION
This change enforces the no-nested-ternary rule in ESLint, preventing nested ternaries that make the code harder to read.

 For more information see: https://eslint.org/docs/latest/rules/no-nested-ternary

<img width="791" height="115" alt="image" src="https://github.com/user-attachments/assets/0e9d6a43-439f-4fd5-bc74-d645bdc92223" />
